### PR TITLE
158 buttons dont indicate that the user has already clicked

### DIFF
--- a/client/src/components/endRound/EndRound.vue
+++ b/client/src/components/endRound/EndRound.vue
@@ -4,8 +4,11 @@
     <response-list :selectable="false" :height="45" :player-id="responsesId" />
     <player-chooser v-model="selectedId" class="w-50 w-lg-25 fs-4 mb-3" />
     <button
-      class="btn btn-orange w-75 w-lg-50 w-xl-25 fs-4 mb-3 position-relative"
-      :class="{ 'btn-blue': !pressedVote }"
+      class="btn btn-blue w-75 w-lg-50 w-xl-25 fs-4 mb-3 position-relative"
+      :class="{
+        'text-white shadow': !pressedVote,
+        'text-white-50 shadow-none': pressedVote
+      }"
       @click="sendVote">
       {{ hasNextRound ? $t('startNextRound') : $t('viewResults') }}
       <notification-count
@@ -63,6 +66,8 @@ export default defineComponent({
   },
   methods: {
     sendVote() {
+      this.pressedVote = !this.pressedVote;
+
       new AudioWrap(ClickMp3).play();
       socket.emit('pollVote', 'startNextRound');
     },

--- a/client/src/components/endRound/EndRound.vue
+++ b/client/src/components/endRound/EndRound.vue
@@ -5,7 +5,7 @@
     <player-chooser v-model="selectedId" class="w-50 w-lg-25 fs-4 mb-3" />
     <button
       class="btn btn-orange w-75 w-lg-50 w-xl-25 fs-4 mb-3 position-relative"
-      :class="{ 'btn-blue': !startNextRoundNext }"
+      :class="{ 'btn-blue': !pressedVote }"
       @click="sendVote">
       {{ hasNextRound ? $t('startNextRound') : $t('viewResults') }}
       <notification-count
@@ -41,7 +41,8 @@ export default defineComponent({
   data() {
     return {
       responsesId: '',
-      selectedId: ''
+      selectedId: '',
+      pressedVote: false
     };
   },
   computed: {

--- a/client/src/components/endRound/EndRound.vue
+++ b/client/src/components/endRound/EndRound.vue
@@ -8,7 +8,10 @@
       :class="{ 'btn-blue': !startNextRoundNext }"
       @click="sendVote">
       {{ hasNextRound ? $t('startNextRound') : $t('viewResults') }}
-      <notification-count v-if="startNextRoundCount" class="position-absolute top-0 start-100 translate-middle fs-6">
+      <notification-count
+        v-if="startNextRoundCount"
+        class="position-absolute top-0 start-100 translate-middle fs-6"
+        :next-majority="startNextRoundNext">
         {{ $n(startNextRoundCount) }}
       </notification-count>
     </button>

--- a/client/src/components/gameShared/NotificationCount.vue
+++ b/client/src/components/gameShared/NotificationCount.vue
@@ -1,10 +1,9 @@
 <template>
   <span
     :style="cssProps"
-    class="rounded-pill badge bg-orange d-inline-flex align-items-center justify-content-center p-0"
-    :class="{ 'bg-blue': !nextMajority }">
+    class="rounded-pill badge d-inline-flex align-items-center justify-content-center p-0"
+    :class="{ 'bg-blue': !nextMajority, 'bg-orange': nextMajority }">
     <slot />
-    {{ nextMajority }}
   </span>
 </template>
 

--- a/client/src/components/gameShared/NotificationCount.vue
+++ b/client/src/components/gameShared/NotificationCount.vue
@@ -1,8 +1,10 @@
 <template>
   <span
     :style="cssProps"
-    class="rounded-pill badge bg-burgundy d-inline-flex align-items-center justify-content-center p-0">
+    class="rounded-pill badge bg-orange d-inline-flex align-items-center justify-content-center p-0"
+    :class="{ 'bg-blue': !nextMajority }">
     <slot />
+    {{ nextMajority }}
   </span>
 </template>
 
@@ -14,6 +16,10 @@ export default defineComponent({
     width: {
       type: Number,
       default: 24
+    },
+    nextMajority: {
+      type: Boolean,
+      default: false
     }
   },
   computed: {

--- a/client/src/components/gameShared/NotificationCount.vue
+++ b/client/src/components/gameShared/NotificationCount.vue
@@ -2,7 +2,7 @@
   <span
     :style="cssProps"
     class="rounded-pill badge d-inline-flex align-items-center justify-content-center p-0"
-    :class="{ 'bg-blue': !nextMajority, 'bg-orange': nextMajority }">
+    :class="{ 'bg-burgundy': !nextMajority, 'bg-orange': nextMajority }">
     <slot />
   </span>
 </template>

--- a/client/src/components/promptResponse/VoteSkip.vue
+++ b/client/src/components/promptResponse/VoteSkip.vue
@@ -1,8 +1,8 @@
 <template>
   <a
     v-tooltip.right="$t('tooltip.voteSkip')"
-    class="btn btn-sm btn-orange text-white ratio-1x1 position-relative d-inline-flex justify-content-center align-items-center"
-    :class="{ 'btn-blue': !skipVoteNext }"
+    class="btn btn-sm btn-orange text-white ratio-1x1 position-relative d-inline-flex justify-content-center align-items-center active"
+    :class="{ 'btn-blue': !pressedVote }"
     @click="sendVote">
     <i class="bi-hand-thumbs-down fs-3 p-0 lh-sm" />
 
@@ -31,7 +31,8 @@ export default defineComponent({
   },
   data() {
     return {
-      tooltips: []
+      tooltips: [],
+      pressedVote: false
     };
   },
   computed: {
@@ -39,6 +40,7 @@ export default defineComponent({
   },
   methods: {
     sendVote() {
+      this.pressedVote = !this.pressedVote;
       new AudioWrap(ClickMp3).play();
       socket.emit('pollVote', 'skipPrompt');
     }

--- a/client/src/components/promptResponse/VoteSkip.vue
+++ b/client/src/components/promptResponse/VoteSkip.vue
@@ -1,11 +1,13 @@
 <template>
   <a
     v-tooltip.right="$t('tooltip.voteSkip')"
-    class="btn btn-sm btn-orange text-white ratio-1x1 position-relative d-inline-flex justify-content-center align-items-center active"
-    :class="{ 'btn-blue': !pressedVote }"
+    class="btn btn-sm btn-blue ratio-1x1 position-relative d-inline-flex justify-content-center align-items-center"
+    :class="{
+      'text-white shadow': !pressedVote,
+      'text-white-50 shadow-none': pressedVote
+    }"
     @click="sendVote">
     <i class="bi-hand-thumbs-down fs-3 p-0 lh-sm" />
-
     <notification-count
       v-if="skipVoteCount"
       :width="22"

--- a/client/src/components/promptResponse/VoteSkip.vue
+++ b/client/src/components/promptResponse/VoteSkip.vue
@@ -9,7 +9,8 @@
     <notification-count
       v-if="skipVoteCount"
       :width="22"
-      class="position-absolute top-0 start-100 translate-middle fs-6">
+      class="position-absolute top-0 start-100 translate-middle fs-6"
+      :next-majority="skipVoteNext">
       {{ $n(skipVoteCount) }}
     </notification-count>
   </a>

--- a/client/src/components/responseMatching/DisputeIcon.vue
+++ b/client/src/components/responseMatching/DisputeIcon.vue
@@ -57,7 +57,7 @@ export default defineComponent({
   },
   methods: {
     sendVote() {
-      this.pressedVote = !this.pressedVote
+      this.pressedVote = !this.pressedVote;
 
       new AudioWrap(ClickMp3).play();
       socket.emit('pollVote', 'sikeDispute');

--- a/client/src/components/responseMatching/DisputeIcon.vue
+++ b/client/src/components/responseMatching/DisputeIcon.vue
@@ -2,7 +2,7 @@
   <button
     v-tooltip="{ title: $t('tooltip.dispute', { response }), placement }"
     class="btn btn-sm btn-orange text-white ratio-1x1 position-relative d-inline-flex justify-content-center align-items-center"
-    :class="{ 'btn-blue': !sikeDisputeNext }"
+    :class="{ 'btn-blue': !pressedVote }"
     :disabled="disabled"
     @click="sendVote">
     <i class="bi-hand-thumbs-down fs-5 lh-sm" />
@@ -45,7 +45,8 @@ export default defineComponent({
   },
   data() {
     return {
-      tooltips: []
+      tooltips: [],
+      pressedVote: false
     };
   },
   computed: {

--- a/client/src/components/responseMatching/DisputeIcon.vue
+++ b/client/src/components/responseMatching/DisputeIcon.vue
@@ -1,8 +1,11 @@
 <template>
   <button
     v-tooltip="{ title: $t('tooltip.dispute', { response }), placement }"
-    class="btn btn-sm btn-orange text-white ratio-1x1 position-relative d-inline-flex justify-content-center align-items-center"
-    :class="{ 'btn-blue': !pressedVote }"
+    class="btn btn-sm btn-blue ratio-1x1 position-relative d-inline-flex justify-content-center align-items-center"
+    :class="{
+      'text-white shadow': !pressedVote,
+      'text-white-50 shadow-none': pressedVote
+    }"
     :disabled="disabled"
     @click="sendVote">
     <i class="bi-hand-thumbs-down fs-5 lh-sm" />
@@ -54,6 +57,8 @@ export default defineComponent({
   },
   methods: {
     sendVote() {
+      this.pressedVote = !this.pressedVote
+
       new AudioWrap(ClickMp3).play();
       socket.emit('pollVote', 'sikeDispute');
     }

--- a/client/src/components/responseMatching/DisputeIcon.vue
+++ b/client/src/components/responseMatching/DisputeIcon.vue
@@ -6,8 +6,11 @@
     :disabled="disabled"
     @click="sendVote">
     <i class="bi-hand-thumbs-down fs-5 lh-sm" />
-
-    <notification-count v-if="sikeDisputeCount" :width="21" class="position-absolute top-0 start-100 translate-middle">
+    <notification-count
+      v-if="sikeDisputeCount"
+      :width="22"
+      class="position-absolute top-0 start-100 translate-middle"
+      :next-majority="sikeDisputeNext">
       {{ $n(sikeDisputeCount) }}
     </notification-count>
   </button>


### PR DESCRIPTION
Changed the behaviour of buttons that persist after being clicked: Voting to skip a prompt, end the round, and dispute things.
Unclicked:
![image](https://github.com/ConorMurphy21/StrikeOrSike/assets/45193617/eb9d39d4-a7ce-4d6a-ab87-e8eea07ae870)
Clicking darkens the button's white component, removes the dropshadow to "flatten" the button, and records vote on the badge icon:
![image](https://github.com/ConorMurphy21/StrikeOrSike/assets/45193617/09eb750e-d803-4d9b-8a54-b7239faaf6dc)
When the next vote will cause an action to occur, the badge turns orange:
![image](https://github.com/ConorMurphy21/StrikeOrSike/assets/45193617/7f38fbc9-f245-4d4c-b3d8-a16aab117013)
Current player has not clicked, but another player has:
![image](https://github.com/ConorMurphy21/StrikeOrSike/assets/45193617/80287a01-0327-48c6-b2ce-6b86db7d75c8)

Similar examples with thumbs down icon:
![image](https://github.com/ConorMurphy21/StrikeOrSike/assets/45193617/9d7d44ce-135c-42e0-b491-2af5ccedfc93)![image](https://github.com/ConorMurphy21/StrikeOrSike/assets/45193617/691145cf-a5c3-4b46-9ffa-80f4babd0af4)
