### PR TITLE
migrate to bootstrap 5.3.3

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -27,7 +27,7 @@
       <option name="INTERPOLATION_NEW_LINE_BEFORE_END_DELIMITER" value="false" />
     </VueCodeStyleSettings>
     <codeStyleSettings language="HTML">
-      <option name="SOFT_MARGINS" value="80" />
+      <option name="SOFT_MARGINS" value="120" />
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />
         <option name="CONTINUATION_INDENT_SIZE" value="2" />
@@ -35,7 +35,7 @@
       </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="JavaScript">
-      <option name="SOFT_MARGINS" value="80" />
+      <option name="SOFT_MARGINS" value="120" />
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />
         <option name="CONTINUATION_INDENT_SIZE" value="2" />
@@ -43,7 +43,7 @@
       </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="TypeScript">
-      <option name="SOFT_MARGINS" value="80" />
+      <option name="SOFT_MARGINS" value="120" />
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />
         <option name="CONTINUATION_INDENT_SIZE" value="2" />
@@ -51,7 +51,7 @@
       </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="Vue">
-      <option name="SOFT_MARGINS" value="80" />
+      <option name="SOFT_MARGINS" value="120" />
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="2" />
       </indentOptions>

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@popperjs/core": "^2.11.6",
     "bootstrap": "^5.3.3",
-    "bootstrap-icons": "^1.11.0",
+    "bootstrap-icons": "^1.11.3",
     "pinia": "^2.1.7",
     "portal-vue": "^3.0.0",
     "socket.io-client": "^4.7.2",

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@popperjs/core": "^2.11.6",
-    "bootstrap": "5.0.2",
+    "bootstrap": "^5.3.3",
     "bootstrap-icons": "^1.11.0",
     "pinia": "^2.1.7",
     "portal-vue": "^3.0.0",
@@ -29,7 +29,7 @@
     "@vue/tsconfig": "^0.5.1",
     "autoprefixer": "^10.4.16",
     "pinia-logger": "^1.3.12",
-    "sass": "^1.69.5",
+    "sass": "^1.71.1",
     "vite": "^5.0.10"
   }
 }

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -32,7 +32,9 @@ function onLogoClick() {
         :role="canNavigateHome ? 'button' : ''"
         @click="onLogoClick" />
       <router-view class="mt-2 mb-5" />
-      <portal-target name="banner" class="mb-2" />
+      <div class="mb-2">
+        <portal-target name="banner" />
+      </div>
     </div>
   </div>
 </template>

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -8,7 +8,7 @@ import PortalVue from 'portal-vue';
 
 // only import bootstrap components that are used
 import { Collapse, Dropdown } from 'bootstrap';
-import 'bootstrap-icons/font/bootstrap-icons.css';
+import 'bootstrap-icons/font/bootstrap-icons.min.css';
 import { useGameStore } from '@/stores/game.js';
 import { useRoomStore } from '@/stores/room.js';
 import socket from '@/socket/socket.js';

--- a/client/src/styles/_min-bootstrap.scss
+++ b/client/src/styles/_min-bootstrap.scss
@@ -38,4 +38,4 @@
 @import '~bootstrap/scss/utilities/api';
 
 // Icons
-@import '~bootstrap-icons/font/bootstrap-icons';
+@import '~bootstrap-icons/font/bootstrap-icons.min.css';

--- a/client/src/styles/_min-bootstrap.scss
+++ b/client/src/styles/_min-bootstrap.scss
@@ -1,12 +1,10 @@
 // 4. Include any optional Bootstrap components as you like
-@import '~bootstrap/scss/functions';
-@import '~bootstrap/scss/variables';
 @import '~bootstrap/scss/mixins';
 @import '~bootstrap/scss/root';
-@import '~bootstrap/scss/utilities';
-@import '~bootstrap/scss/helpers';
 
 // Layout & components
+@import '~bootstrap/scss/utilities';
+@import '~bootstrap/scss/helpers';
 @import '~bootstrap/scss/reboot';
 @import '~bootstrap/scss/type';
 @import '~bootstrap/scss/images';

--- a/client/src/styles/_variables.scss
+++ b/client/src/styles/_variables.scss
@@ -16,21 +16,21 @@ $header-font: Pacifico, 'Brush Script MT', cursive;
 
 $border-radius: 0.7rem;
 
-$theme-colors: (
-  'primary': $primary,
-  'secondary': $secondary,
-  'orange': $orange,
-  'yellow': $yellow,
-  'blue': $blue,
-  'red': $red,
-  'burgundy': $burgundy,
-  'dark': $dark
-);
-
 // 3. Include remainder of required Bootstrap stylesheets
 @import '~bootstrap/scss/variables';
 
+$theme-colors: (
+        'primary': $primary,
+        'secondary': $secondary,
+        'orange': $orange,
+        'yellow': $yellow,
+        'blue': $blue,
+        'red': $red,
+        'burgundy': $burgundy,
+        'dark': $dark
+);
+
+@import '~bootstrap/scss/maps';
+
 $tooltip-bg: $gray-600;
 $tooltip-arrow-color: $tooltip-bg;
-
-@import '~bootstrap/scss/mixins';

--- a/client/src/styles/_variables.scss
+++ b/client/src/styles/_variables.scss
@@ -1,6 +1,18 @@
 // 1. Include functions first (so you can manipulate colors, SVGs, calc, etc)
 @import '~bootstrap/scss/functions';
 
+$white:    #fff;
+$gray-100: #f8f9fa;
+$gray-200: #e9ecef;
+$gray-300: #dee2e6;
+$gray-400: #ced4da;
+$gray-500: #adb5bd;
+$gray-600: #6c757d;
+$gray-700: #495057;
+$gray-800: #343a40;
+$gray-900: #212529;
+$black:    #000;
+
 // 2. Include any default variable overrides here
 $orange: #ff6415;
 $blue: #165dcf;
@@ -11,23 +23,83 @@ $primary: $orange;
 $secondary: #f6f3f0;
 $dark: #212529;
 
+$orange-text-emphasis: shade-color($orange, 60%);
+$blue-text-emphasis: shade-color($blue, 60%);
+$red-text-emphasis: shade-color($red, 60%);
+$burgundy-text-emphasis: shade-color($burgundy, 60%);
+$yellow-text-emphasis: shade-color($yellow, 60%);
+$primary-text-emphasis: $orange-text-emphasis;
+$secondary-text-emphasis: $gray-700;
+$dark-text-emphasis: $gray-700;
+
+$orange-bg-subtle: tint-color($orange, 80%);
+$blue-bg-subtle: tint-color($blue, 80%);
+$red-bg-subtle: tint-color($red, 80%);
+$burgundy-bg-subtle: tint-color($burgundy, 80%);
+$yellow-bg-subtle: tint-color($yellow, 80%);
+$primary-bg-subtle: $orange-bg-subtle;
+$secondary-bg-subtle: mix($gray-100, $white);
+$dark-bg-subtle: $gray-400;
+
+$orange-border-subtle: tint-color($orange, 60%);
+$blue-border-subtle: tint-color($blue, 60%);
+$red-border-subtle: tint-color($red, 60%);
+$burgundy-border-subtle: tint-color($burgundy, 60%);
+$yellow-border-subtle: tint-color($yellow, 60%);
+$primary-border-subtle: $orange-border-subtle;
+$secondary-border-subtle: $gray-200;
+$dark-border-subtle: $gray-500;
+
 $main-font: Quicksand, 'Lucida Handwriting', cursive;
 $header-font: Pacifico, 'Brush Script MT', cursive;
 
 $border-radius: 0.7rem;
 
+$theme-colors: (
+  'primary': $primary,
+  'secondary': $secondary,
+  'orange': $orange,
+  'yellow': $yellow,
+  'blue': $blue,
+  'red': $red,
+  'burgundy': $burgundy,
+  'dark': $dark
+);
+
 // 3. Include remainder of required Bootstrap stylesheets
 @import '~bootstrap/scss/variables';
 
-$theme-colors: (
-        'primary': $primary,
-        'secondary': $secondary,
-        'orange': $orange,
-        'yellow': $yellow,
-        'blue': $blue,
-        'red': $red,
-        'burgundy': $burgundy,
-        'dark': $dark
+$theme-colors-text: (
+  'primary': $primary-text-emphasis,
+  'secondary': $secondary-text-emphasis,
+  'orange': $orange-text-emphasis,
+  'yellow': $yellow-text-emphasis,
+  'blue': $blue-text-emphasis,
+  'red': $red-text-emphasis,
+  'burgundy': $burgundy-text-emphasis,
+  'dark': $dark-text-emphasis
+);
+
+$theme-colors-bg-subtle: (
+  'primary': $primary-bg-subtle,
+  'secondary': $secondary-bg-subtle,
+  'orange': $orange-bg-subtle,
+  'yellow': $yellow-bg-subtle,
+  'blue': $blue-bg-subtle,
+  'red': $red-bg-subtle,
+  'burgundy': $burgundy-bg-subtle,
+  'dark': $dark-bg-subtle
+);
+
+$theme-colors-border-subtle: (
+  'primary': $primary-border-subtle,
+  'secondary': $secondary-border-subtle,
+  'orange': $orange-border-subtle,
+  'yellow': $yellow-border-subtle,
+  'blue': $blue-border-subtle,
+  'red': $red-border-subtle,
+  'burgundy': $burgundy-border-subtle,
+  'dark': $dark-border-subtle
 );
 
 @import '~bootstrap/scss/maps';

--- a/client/src/styles/app.scss
+++ b/client/src/styles/app.scss
@@ -1,5 +1,5 @@
-@import 'min-bootstrap';
 @import 'variables';
+@import 'min-bootstrap';
 @import 'loading-icon';
 @import 'animations';
 @import 'slider-component';

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@vue/tsconfig": "^0.5.1",
         "autoprefixer": "^10.4.16",
         "bootstrap": "^5.3.3",
-        "bootstrap-icons": "^1.11.0",
+        "bootstrap-icons": "^1.11.3",
         "pinia": "^2.1.7",
         "pinia-logger": "^1.3.12",
         "portal-vue": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,12 +43,12 @@
         "@vitejs/plugin-vue": "^5.0.2",
         "@vue/tsconfig": "^0.5.1",
         "autoprefixer": "^10.4.16",
-        "bootstrap": "5.0.2",
+        "bootstrap": "^5.3.3",
         "bootstrap-icons": "^1.11.0",
         "pinia": "^2.1.7",
         "pinia-logger": "^1.3.12",
         "portal-vue": "^3.0.0",
-        "sass": "^1.69.5",
+        "sass": "^1.71.1",
         "socket.io-client": "^4.7.2",
         "vite": "^5.0.10",
         "vue": "^3.2.47",
@@ -3513,16 +3513,22 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.2.tgz",
-      "integrity": "sha512-1Ge963tyEQWJJ+8qtXFU6wgmAVj9gweEjibUdbmcCEYsn38tVwRk8107rk2vzt6cfQcRr3SlZ8aQBqaD8aqf+Q==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
       "peerDependencies": {
-        "@popperjs/core": "^2.9.2"
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/bootstrap-icons": {
@@ -6915,9 +6921,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.69.7",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.7.tgz",
-      "integrity": "sha512-rzj2soDeZ8wtE2egyLXgOOHQvaC2iosZrkF6v3EUG+tBwEvhqUCzm0VP3k9gHF9LXbSrRhT5SksoI56Iw8NPnQ==",
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.71.1.tgz",
+      "integrity": "sha512-wovtnV2PxzteLlfNzbgm1tFXPLoZILYAMJtvoXXkD7/+1uP41eKkIt1ypWq5/q2uT94qHjXehEYfmjKOvjL9sg==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",

--- a/server/webpack.config.js
+++ b/server/webpack.config.js
@@ -40,5 +40,8 @@ module.exports = {
         loader: 'node-loader'
       }
     ]
+  },
+  stats: {
+    warningsFilter: [/.*\/node_modules\/.*/]
   }
 };


### PR DESCRIPTION
 * This PR was to fix some of the warnings from building and in dev console
 * Fix warning about bootstrap-icons not being imported
 * Suppress warnings from node_modules in webpack build
 * Override more custom color variables and color maps from bootstrap to fix regressions from bootstrap version  bump